### PR TITLE
COPY: "Duplicate email" functionality

### DIFF
--- a/client/jsx/emails/EmailControls.jsx
+++ b/client/jsx/emails/EmailControls.jsx
@@ -41,20 +41,15 @@ class EmailControls extends React.Component {
 	}
 
 	handleCopy() {
-		fetch('/api/copyEmail', {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json'
-			},
-			body: JSON.stringify({
-				'id':	Object.keys(this.props.selectedCheckboxes)
-			})
-		})
-		.then((response) => {
-			this.props.refreshEmailList()
-			return response.text()
-		})
-	}	
+		// handle any undefined behavior with the 'OR' assignment
+		const duplicate_id = Object.keys(this.props.selectedCheckboxes)[0] || ''
+
+		axios.post('/api/email/copy', { id: duplicate_id })
+			.then(res => {
+				this.props.refreshEmailList()
+				return res.text()
+			}).catch(console.log)
+	}
 
 	handleSearch() {
 		const searchText = this.state.searchValue
@@ -79,7 +74,7 @@ class EmailControls extends React.Component {
 				<input className="input" type="text" placeholder="Doesn't work yet" value={this.state.searchValue} onChange={this.handleSearchChange} />
 				<button className="button" onClick={this.handleSearch}>Search</button>
 				<button className="button" onClick={this.clearSearch}>Clear</button>
-				
+
 			</div>
 		)
 	}

--- a/client/jsx/emails/EmailControls.jsx
+++ b/client/jsx/emails/EmailControls.jsx
@@ -41,10 +41,13 @@ class EmailControls extends React.Component {
 	}
 
 	handleCopy() {
-		// handle any undefined behavior with the 'OR' assignment
-		const duplicate_id = Object.keys(this.props.selectedCheckboxes)[0] || ''
+		// guard clause: prevent the duplication of more than one email
+		const selected = Object.keys(this.props.selectedCheckboxes)
+		if (selected.length !== 1) {
+			return null
+		}
 
-		axios.post('/api/email/copy', { id: duplicate_id })
+		axios.post('/api/email/copy', { id: selected[0] })
 			.then(res => {
 				this.props.refreshEmailList()
 				return res.text()

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -172,13 +172,13 @@ router.post('/search', jsonParser, (req, res) => {
 })
 
 router.post('/copy', jsonParser, (req, res) => {
-	console.log('hi')
 	const id = req.body.id
 	const createdAt = Utils.getCurrentTimestampUTC()
 	const updatedAt = Utils.getCurrentTimestampUTC()
 	let copyData
 
-	if (!id) {
+	// guard clause: prevent non-string ID
+	if (!id || typeof id !== 'string') {
 		return res.status(400).json({message: 'Did not pass valid email to duplicate'})
 	}
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -37,7 +37,7 @@ router.get('/list/:skip?', jsonParser, (req, res) => {
 		console.log(err)
 		throw err
 	})
-	
+
 })
 
 router.get('/templates', (req, res) => {
@@ -56,7 +56,7 @@ router.get('/templates', (req, res) => {
 })
 
 router.post('/compileTemplate', jsonParser, (req,res) => {
-	
+
 	const context = JSON.parse(req.body.context)
 	const template = context.template
 
@@ -75,7 +75,7 @@ router.post('/create', jsonParser, (req,res) => {
 	const { content, title } = req.body
 	const createdAt = Utils.getCurrentTimestampUTC()
 	const updatedAt = Utils.getCurrentTimestampUTC()
-	
+
 	axios.get(COUCH_UUID)
 		.then((response) => {
 			let uuid = response.data.uuids[0]
@@ -105,7 +105,7 @@ router.post('/create', jsonParser, (req,res) => {
 			console.log('---error in /email/create---')
 			console.log(err)
 		})
-	
+
 })
 
 router.get('/:id', (req, res) => {
@@ -171,8 +171,37 @@ router.post('/search', jsonParser, (req, res) => {
 	})
 })
 
-// router.post('/copyEmail', jsonParser, (req, res) => {
-// 	const id = req.body.id[0]
-// })
+router.post('/copy', jsonParser, (req, res) => {
+	console.log('hi')
+	const id = req.body.id
+	const createdAt = Utils.getCurrentTimestampUTC()
+	const updatedAt = Utils.getCurrentTimestampUTC()
+	let copyData
+
+	if (!id) {
+		return res.status(400).json({message: 'Did not pass valid email to duplicate'})
+	}
+
+	// get the data, snag a uuid, then post the data to that id. respond with data
+	axios.get(COUCH_EMAILS + id)
+	.then(result => {
+		copyData = result.data
+		return axios.get(COUCH_UUID)
+	}).then(result => {
+		const uuid = result.data.uuids[0]
+		return axios.put(COUCH_EMAILS + uuid, {
+			content: copyData.content,
+			title: copyData.title,
+			template: copyData.template || '',
+			templates: copyData.templates || [],
+			createdAt: createdAt,
+			updatedAt: updatedAt
+		})
+	}).then(result => {
+		return axios.get(COUCH_EMAILS + result.data.id)
+	}).then(final => {
+		return res.send(final.data)
+	}).catch(err => res.status(500).json({message: err.message}))
+})
 
 export { router as API }


### PR DESCRIPTION
![screenshot from 2017-03-06 18-45-09](https://cloud.githubusercontent.com/assets/6923449/23635524/5c4a6664-029e-11e7-836c-ab832f856d43.png)

Selecting an email and clicking COPY will create a new entry in the Emails table, duplicating the email that the user selected.

Validation/error-handling:

Client side:
- Only posts to server if the `selectedCheckboxes` prop has a length of exactly 1.
- Post the ID (as a string)

Server side:
- Only posts to DB if `req.body.id` is a string (otherwise, sends back a 400)
- Catch and resolve all other read/write errors with 500s