### PR TITLE
Auth integration: express, passport, and redis

### DIFF
--- a/server/lib/app.js
+++ b/server/lib/app.js
@@ -63,9 +63,8 @@ app.use(expressSession({
 	}
 }))
 
-app.use('/api', passport.verifySession)
 passport.init(app)
-
+app.use('/api', passport.verifySession)
 
 
 // routes (api, logging, and catchalls)

--- a/server/lib/app.js
+++ b/server/lib/app.js
@@ -5,6 +5,8 @@ const path = require('path')
 const fs = require('fs')
 const gzipStatic = require('connect-gzip-static')
 const expressSession = require('express-session')
+const RedisStore = require('connect-redis')(expressSession)
+const redisClient = require('./redis.js')
 const paths = require('../../config/paths')
 const jsonParser = require('body-parser').json()
 const passport = require('../routes/auth.js')
@@ -14,7 +16,6 @@ require('winston-loggly-bulk')
 dotenv.config()
 
 const { NODE_ENV, SESSION_SECRET } = process.env
-
 
 
 
@@ -46,6 +47,11 @@ if(NODE_ENV === 'production') {
 app.use('/public', gzipStatic(paths.build))
 
 app.use(expressSession({
+	store: new RedisStore({
+		client: redisClient,
+		ttl: 86400,     // 24 hours
+		prefix: 'sess-'
+	}),
 	secret: SESSION_SECRET,
 	resave: false,
 	saveUninitialized: false,

--- a/server/lib/app.js
+++ b/server/lib/app.js
@@ -39,10 +39,8 @@ else {
 	}
 }
 
-// express and passportjs config
-// init static route before expressSession
-// init expressSession before passport
-let app = express()
+const app = express()
+
 app.use('/public', gzipStatic(paths.build))
 
 app.use(expressSession({
@@ -84,7 +82,7 @@ app.get('/__health-check__', (req, res) => {
 })
 
 //sendfile for any routes that don't match
-app.get('*', (req, res) => {
+app.get('*', passportjs.verifySession, (req, res) => {
 	res.sendFile('index.html', {
 		root: process.env.PWD + '/public'
 	}, (err) => {

--- a/server/lib/redis.js
+++ b/server/lib/redis.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const Redis = require('ioredis')
+
+module.exports = new Redis({
+	port: 6379,
+	host: '127.0.0.1',
+	reconnectOnError: (err) => {
+		const targetError = 'READONLY'
+		return err.message.slice(0, targetError.length) === targetError
+	}
+})

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,13 +3,11 @@ const bodyParser = require('body-parser')
 const axios = require('axios')
 const passport = require('passport')
 const LocalStrategy = require('passport-local').Strategy
-const redis = require('redis')
 const winston = require('winston')
 
 dotenv.config()
 
 const AUTH_URL = process.env.AUTH_URL
-const redisClient = redis.createClient()
 const jsonParser = bodyParser.json()
 const passportjs = {}
 
@@ -69,52 +67,9 @@ passportjs.init = (app) => {
 		successRedirect: '/'
 	}))
 
-	app.delete('/api/auth/:uid', (req, res) => {
-		const uid = req.params.uid
-		redisClient.del(uid, (err, deletedRecords) => {
-			if(!err && deletedRecords > 0) {
-				res.sendStatus(200)
-			}
-			else if(!err && deletedRecords < 1) {
-				res.sendStatus(404)
-			}
-			else {
-				// TODO: system log error
-				console.log(err)
-				res.status(500).send(err)
-			}
-		})
-	})
-
 	app.get('/api/auth/logout', (req, res) => {
-		const sessionID = `sess-${req.session.id}`
-		redisClient.del(sessionID, (err) => {
-			if(!err) {
-				req.logout()
-				res.redirect('/login')
-			}
-			else {
-				winston.error(err)
-				req.logout()
-				res.status(500).send(err)
-			}
-		})
-	})
-
-	app.get('/api/auth/verify/:uid', (req, res) => {
-		const uid = req.params.uid
-		redisClient.get(uid, (err, data) => {
-			if(err) {
-				winston.error(err)
-				res.sendStatus(500)
-			}
-			else if(!data) {
-				res.sendStatus(404)
-			}
-			else if(data) {
-				res.sendStatus(200)
-			}
-		})
+		req.logout()
+		res.redirect('/login')
 	})
 }
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -29,7 +29,7 @@ const authenticate = (username, password, done) => {
 		} else {
 			return done(null, userObj.data.user)
 		}
-	}).catch(done)
+	}).catch(err => done(null, false, err))
 }
 
 
@@ -119,28 +119,15 @@ passportjs.init = (app) => {
 }
 
 passportjs.verifySession = (req, res, next) => {
-	let sess = req.session && req.session.passport ? req.session.passport.user : null
-
-	if(req.originalUrl.includes('/login')) {
+	// skip /login routes
+	if (req.originalUrl.includes('/login')) {
 		next()
-	}
-
-	else if(!sess) {
+	} else if (req.isAuthenticated && req.isAuthenticated()) {
+		next()
+	// redirect on browser routes; send Forbidden on api routes
+	} else {
 		req.originalUrl.includes('/api') ? res.sendStatus(403) : res.redirect('/login')
 	}
-
-	else {
-		redisClient.ttl(sess, err => {
-			if(!err) {
-				next()
-			}
-			else {
-				winston.error(err)
-				res.status(500).send(err)
-			}
-		})
-	}
-
 }
 
 module.exports = passportjs

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -149,12 +149,12 @@ passportjs.init = (app) => {
 passportjs.verifySession = (req, res, next) => {
 	let sess = req.session && req.session.passport ? req.session.passport.user : null
 
-	if(req.originalUrl.includes('/api/auth/login')) {
+	if(req.originalUrl.includes('/login')) {
 		next()
 	}
 
-	else if(!sess && !req.xhr) {
-		res.sendStatus(403)
+	else if(!sess) {
+		res.redirect('/login')
 	}
 
 	else {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -154,7 +154,7 @@ passportjs.verifySession = (req, res, next) => {
 	}
 
 	else if(!sess) {
-		res.redirect('/login')
+		req.originalUrl.includes('/api') ? res.sendStatus(403) : res.redirect('/login')
 	}
 
 	else {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -119,7 +119,7 @@ passportjs.init = (app) => {
 		redisClient.del(sessionID, (err) => {
 			if(!err) {
 				req.logout()
-				res.sendStatus(403)
+				res.redirect('/login')
 			}
 			else {
 				winston.error(err)

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,7 @@
+const router = require('express').Router()
+
+router.use('/api/email', require('./api.js'))
+router.use('/api/s3', require('./s3.js'))
+router.use('/api/meta', require('./meta.js'))
+
+module.exports = router

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const router = require('express').Router()
 
 router.use('/api/email', require('./api.js'))

--- a/test/spec/api-test.js
+++ b/test/spec/api-test.js
@@ -111,7 +111,63 @@ describe('Mailroad API: /api/*', function () {
         });
      });
 
-     // TODO: DELETE /auth/:uid, GET /auth/logout, GET /auth/verify/:uid
+     it('GET /api/auth/logout: logs out a logged-in user', function (done) {
+       login((agent, cookie) => {
+         agent
+          .get('/api/auth/logout')
+          .set('Cookie', cookie)
+          .expect(302)
+          .end((err, res) => {
+            res.status.should.equal(302);
+            res.headers.location.should.equal('/login');
+            done();
+          });
+       });
+     });
+
+     it('GET /: redirects a user to /login if not logged in', function (done) {
+       request.agent(app)
+        .get('/')
+        .expect(302)
+        .end((err, res) => {
+          res.status.should.equal(302);
+          res.headers.location.should.equal('/login');
+          done();
+        });
+     });
+
+     it('GET /editor: redirects a user to /login if not logged in', function (done) {
+       request.agent(app)
+        .get('/editor')
+        .expect(302)
+        .end((err, res) => {
+          res.status.should.equal(302);
+          res.headers.location.should.equal('/login');
+          done();
+        });
+     });
+
+     it('GET /admin: redirects a user to /login if not logged in', function (done) {
+       request.agent(app)
+        .get('/admin')
+        .expect(302)
+        .end((err, res) => {
+          res.status.should.equal(302);
+          res.headers.location.should.equal('/login');
+          done();
+        });
+     });
+
+     it('GET /media: redirects a user to /login if not logged in', function (done) {
+       request.agent(app)
+        .get('/media')
+        .expect(302)
+        .end((err, res) => {
+          res.status.should.equal(302);
+          res.headers.location.should.equal('/login');
+          done();
+        });
+     });
    });
 
   /**

--- a/test/spec/api-test.js
+++ b/test/spec/api-test.js
@@ -239,20 +239,18 @@ describe('Mailroad API: /api/*', function () {
      });
 
      it('GET /api/email/list: forbidden request if no cookie sent', function (done) {
-       login((agent, cookie) => {
-         agent
-          .get('/api/email/list')
-          .send({
-            username: process.env.MCI_TEST_USER,
-            password: process.env.MCI_TEST_PASS
-          })
-          .expect(403)
-          .expect('Content-type', /application\/json/)
-          .end((err, res) => {
-            res.status.should.equal(403);
-            done();
-          });
-       });
+       request.agent(app)
+        .get('/api/email/list')
+        .send({
+          username: process.env.MCI_TEST_USER,
+          password: process.env.MCI_TEST_PASS
+        })
+        .expect(403)
+        .expect('Content-type', /application\/json/)
+        .end((err, res) => {
+          res.status.should.equal(403);
+          done();
+        });
      });
 
      it('GET /api/email/list: bad request if no user parameter sent', function (done) {
@@ -311,20 +309,17 @@ describe('Mailroad API: /api/*', function () {
      });
 
      it('GET /api/email/templates: forbidden request if no cookie passed', function (done) {
-       login((agent, cookie) => {
-         agent
-          .get('/api/email/templates')
-          .send({
-            user: process.env.MCI_TEST_USER
-          })
-          .expect(200)
-          .expect('Content-type', /application\/json/)
-          .end((err, res) => {
-            res.status.should.equal(200);
-            res.body.should.be.a.Array();
-            done();
-          });
-       });
+       request.agent(app)
+        .get('/api/email/templates')
+        .send({
+          user: process.env.MCI_TEST_USER
+        })
+        .expect(403)
+        .expect('Content-type', /application\/json/)
+        .end((err, res) => {
+          res.status.should.equal(403);
+          done();
+        });
      });
 
      it('GET /api/email/templates: bad request if no user parameter sent', function (done) {

--- a/test/spec/api-test.js
+++ b/test/spec/api-test.js
@@ -253,38 +253,6 @@ describe('Mailroad API: /api/*', function () {
         });
      });
 
-     it('GET /api/email/list: bad request if no user parameter sent', function (done) {
-       login((agent, cookie) => {
-         agent
-          .get('/api/email/list')
-          .set('Cookie', cookie)
-          .expect(400)
-          .expect('Content-type', /application\/json/)
-          .end((err, res) => {
-            res.status.should.equal(400);
-            done();
-          });
-       });
-     });
-
-     it('GET /api/email/list: forbidden request if the user sent in request does not match logged in user', function (done) {
-       login((agent, cookie) => {
-         agent
-          .get('/api/email/list')
-          .send({
-            user: 'not_the_logged_in_user'
-          })
-          .set('Cookie', cookie)
-          .expect(403)
-          .expect('Content-type', /application\/json/)
-          .end((err, res) => {
-            res.status.should.equal(403);
-            res.text.should.equal('Forbidden');
-            done();
-          });
-       });
-     });
-
 
 
      // fetching templates
@@ -320,38 +288,6 @@ describe('Mailroad API: /api/*', function () {
           res.status.should.equal(403);
           done();
         });
-     });
-
-     it('GET /api/email/templates: bad request if no user parameter sent', function (done) {
-       login((agent, cookie) => {
-         agent
-          .get('/api/email/templates')
-          .set('Cookie', cookie)
-          .expect(400)
-          .expect('Content-type', /application\/json/)
-          .end((err, res) => {
-            res.status.should.equal(400);
-            done();
-          });
-       });
-     });
-
-     it('GET /api/email/templates: forbidden request if the user sent in request does not match logged in user', function (done) {
-       login((agent, cookie) => {
-         agent
-          .get('/api/email/templates')
-          .send({
-            user: 'not_the_logged_in_user'
-          })
-          .set('Cookie', cookie)
-          .expect(403)
-          .expect('Content-type', /application\/json/)
-          .end((err, res) => {
-            res.status.should.equal(403);
-            res.text.should.equal('Forbidden');
-            done();
-          });
-       });
      });
 
 

--- a/test/spec/api-test.js
+++ b/test/spec/api-test.js
@@ -238,6 +238,23 @@ describe('Mailroad API: /api/*', function () {
        });
      });
 
+     it('GET /api/email/list: forbidden request if no cookie sent', function (done) {
+       login((agent, cookie) => {
+         agent
+          .get('/api/email/list')
+          .send({
+            username: process.env.MCI_TEST_USER,
+            password: process.env.MCI_TEST_PASS
+          })
+          .expect(403)
+          .expect('Content-type', /application\/json/)
+          .end((err, res) => {
+            res.status.should.equal(403);
+            done();
+          });
+       });
+     });
+
      it('GET /api/email/list: bad request if no user parameter sent', function (done) {
        login((agent, cookie) => {
          agent
@@ -283,6 +300,23 @@ describe('Mailroad API: /api/*', function () {
             user: process.env.MCI_TEST_USER
           })
           .set('Cookie', cookie)
+          .expect(200)
+          .expect('Content-type', /application\/json/)
+          .end((err, res) => {
+            res.status.should.equal(200);
+            res.body.should.be.a.Array();
+            done();
+          });
+       });
+     });
+
+     it('GET /api/email/templates: forbidden request if no cookie passed', function (done) {
+       login((agent, cookie) => {
+         agent
+          .get('/api/email/templates')
+          .send({
+            user: process.env.MCI_TEST_USER
+          })
           .expect(200)
           .expect('Content-type', /application\/json/)
           .end((err, res) => {


### PR DESCRIPTION
Chunky PR. Here's the ground it covers:

[(T) GIF](https://media.giphy.com/media/o2Lwy4g7Dzptu/giphy.gif)

### `server/routes/auth.js`

- Serialize/deserialize object stored in session
- Redirect to /login any unauthenticated user hitting /*
- Send 403 to unauthenticated requests hitting /api/*
- Clear cached session on logout

### `server/lib/app.js` and `server/lib/index.js`

- Use redis as the session's data store
- Refactor for legibility/maintainability
- index.js is now what fires up the app, whereas app.js just sets configurations

### `server/routes/index.js`

- Define all other routes here

### `tests/*`

- Tests!!!