### PR TITLE
Validation middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "handlebars": "^4.0.5",
     "ioredis": "^3.0.0",
+    "joi": "^10.5.2",
     "juice": "^4.0.2",
     "lodash.merge": "^4.6.0",
     "mjml": "^3.3.0",

--- a/server/lib/mci-couchdb.js
+++ b/server/lib/mci-couchdb.js
@@ -33,7 +33,6 @@ couchdb.listEmails = (skip) => {
 
 couchdb.putEmail = (uuid, options) => {
 	return axios.put(`${COUCH_URL}/${EMAIL_DB}/${uuid}`, merge({}, {
-		// createdAt: Utils.getCurrentTimestampUTC(),
 		updatedAt: Utils.getCurrentTimestampUTC()
 	}, options))
 }
@@ -59,7 +58,9 @@ couchdb.searchEmails = (query) => {
 
 couchdb.createEmail = (options) => {
 	return couchdb.getUniqueUUID().then(uuid => {
-		return couchdb.putEmail(uuid, options)
+		return couchdb.putEmail(uuid, merge({}, {
+			createdAt: Utils.getCurrentTimestampUTC()
+		}, options))
 	})
 }
 

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -33,6 +33,10 @@ exports.schema = {
 			contents: Joi.array().required().error(Error('Invalid "contents" parameter.')),
 			title: Joi.string().required().error(Error('Invalid "title" parameter.'))
 		}),
+		put: Joi.object().keys({
+			id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.')),
+			doc: Joi.object().required().error(Error('Invalid "doc" parameter.'))
+		}),
 		duplicate: Joi.object().keys({
 			id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.'))
 		}),

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -4,49 +4,49 @@ const Joi = require('joi')
 const merge = require('lodash.merge')
 
 exports.validate = (schema, options) => {
-  return function (req, res, next) {
-    const opts = options || { stripUnknown: true }
-    const config = merge({}, req.query, req.params, req.body)
+	return function (req, res, next) {
+		const opts = options || { stripUnknown: true }
+		const config = merge({}, req.query, req.params, req.body)
 
-    const csrf = req.get('X-CSRF-TOKEN')
-    if (csrf) {
-      config._csrf = csrf
-    }
+		const csrf = req.get('X-CSRF-TOKEN')
+		if (csrf) {
+			config._csrf = csrf
+		}
 
-    Joi.validate(config, schema, opts, (err, result) => {
-      if (err) {
-        return res.status(400).type('text/plain').send(err.message)
-      }
+		Joi.validate(config, schema, opts, (err, result) => {
+			if (err) {
+				return res.status(400).type('text/plain').send(err.message)
+			}
 
-      req.joi = result
-      next()
-    })
-  }
+			req.joi = result
+			next()
+		})
+	}
 }
 
 exports.schema = {
-  emails: {
-    list: Joi.object().keys({
-      skip: Joi.number().optional().min(0).error(Error('Invalid "skip" parameter.'))
-    }),
-    create: Joi.object().keys({
-      contents: Joi.array().required().error(Error('Invalid "contents" parameter.')),
-      title: Joi.string().required().error(Error('Invalid "title" parameter.'))
-    }),
-    duplicate: Joi.object().keys({
-      id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.'))
-    }),
-    getOne: Joi.object().keys({
-      id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.'))
-    }),
-    delete: Joi.object().keys({
-      id: Joi.array().items(Joi.string().required()).single().required().error(Error('Invalid "id" parameter.'))
-    }),
-    search: Joi.object().keys({
-      searchText: Joi.string().required().error(Error('Invalid "searchText" parameter.'))
-    }),
-    compile: Joi.object().keys({
-      context: Joi.object().required().error(Error('Invalid "context" parameter.'))
-    })
-  }
+	emails: {
+		list: Joi.object().keys({
+			skip: Joi.number().optional().min(0).error(Error('Invalid "skip" parameter.'))
+		}),
+		create: Joi.object().keys({
+			contents: Joi.array().required().error(Error('Invalid "contents" parameter.')),
+			title: Joi.string().required().error(Error('Invalid "title" parameter.'))
+		}),
+		duplicate: Joi.object().keys({
+			id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.'))
+		}),
+		getOne: Joi.object().keys({
+			id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.'))
+		}),
+		delete: Joi.object().keys({
+			id: Joi.array().items(Joi.string().required()).single().required().error(Error('Invalid "id" parameter.'))
+		}),
+		search: Joi.object().keys({
+			searchText: Joi.string().required().error(Error('Invalid "searchText" parameter.'))
+		}),
+		compile: Joi.object().keys({
+			context: Joi.object().required().error(Error('Invalid "context" parameter.'))
+		})
+	}
 }

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const Joi = require('joi')
+const merge = require('lodash.merge')
+
+exports.validate = (schema, options) => {
+  return function (req, res, next) {
+    const opts = options || { stripUnknown: true }
+    const config = merge({}, req.query, req.params, req.body)
+
+    const csrf = req.get('X-CSRF-TOKEN')
+    if (csrf) {
+      config._csrf = csrf
+    }
+
+    Joi.validate(config, schema, opts, (err, result) => {
+      if (err) {
+        return res.status(400).type('text/plain').send(err.message)
+      }
+
+      req.joi = result
+      next()
+    })
+  }
+}
+
+exports.schema = {
+  emails: {
+    list: Joi.object().keys({
+      skip: Joi.number().optional().min(0).error(Error('Invalid "skip" parameter.'))
+    }),
+    create: Joi.object().keys({
+      contents: Joi.array().required().error(Error('Invalid "contents" parameter.')),
+      title: Joi.string().required().error(Error('Invalid "title" parameter.'))
+    }),
+    duplicate: Joi.object().keys({
+      id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.'))
+    }),
+    getOne: Joi.object().keys({
+      id: Joi.string().required().min(0).error(Error('Invalid "id" parameter.'))
+    }),
+    delete: Joi.object().keys({
+      id: Joi.array().items(Joi.string().required()).single().required().error(Error('Invalid "id" parameter.'))
+    }),
+    search: Joi.object().keys({
+      searchText: Joi.string().required().error(Error('Invalid "searchText" parameter.'))
+    }),
+    compile: Joi.object().keys({
+      context: Joi.object().required().error(Error('Invalid "context" parameter.'))
+    })
+  }
+}

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -8,7 +8,7 @@ const mjml = require('../lib/mjml.js')
 const MJML = new mjml()
 const redis = require('redis')
 const couchdb = require('../lib/mci-couchdb.js')
-const merge = require('lodash.merge')
+const joi = require('../lib/validation.js')
 
 dotenv.config()
 
@@ -16,8 +16,8 @@ let router = express.Router()
 let jsonParser = bodyParser.json()
 const redisClient = redis.createClient()
 
-router.get('/list/:skip?', jsonParser, (req, res) => {
-	const skip = req.query && req.query.skip ? req.query.skip : null
+router.get('/list/:skip?', jsonParser, joi.validate(joi.schema.emails.list), (req, res) => {
+	const skip = req.joi.skip || null
 
 	couchdb.listEmails(skip)
 	.then(emails => {
@@ -46,9 +46,9 @@ router.get('/templates', (req, res) => {
 	})
 })
 
-router.post('/compile', jsonParser, (req,res) => {
+router.post('/compile', jsonParser, joi.validate(joi.schema.emails.compile), (req,res) => {
 
-	const context = JSON.parse(req.body.context)
+	const context = JSON.parse(req.joi.context)
 	const template = context.template
 
 	const parsedMJML = MJML.parseHandlebars(context, template)
@@ -64,8 +64,8 @@ router.post('/compile', jsonParser, (req,res) => {
 	}
 })
 
-router.post('/create', jsonParser, (req,res) => {
-	const { contents, title } = req.body
+router.post('/create', jsonParser, joi.validate(joi.schema.emails.create), (req,res) => {
+	const { contents, title } = req.joi
 	const sessionID = `sess-${req.sessionID}`
 	let user
 
@@ -92,8 +92,8 @@ router.post('/create', jsonParser, (req,res) => {
 	})
 })
 
-router.get('/:id', (req, res) => {
-	couchdb.getEmailByID(req.params.id).then(email => {
+router.get('/:id', joi.validate(joi.schema.emails.getOne), (req, res) => {
+	couchdb.getEmailByID(req.joi.id).then(email => {
 		return res.send(email.data)
 	}).catch(err => {
 		winston.error(err)
@@ -122,14 +122,8 @@ router.put('/:id', jsonParser, (req, res) => {
 
 })
 
-router.delete('/delete', jsonParser, (req, res) => {
-	if (!req.query || !req.query.id) {
-		return res.sendStatus(400)
-	}
-
-	const ids = typeof req.query.id === 'string' ? [req.query.id] : req.query.id
-
-	couchdb.deleteEmails(ids)
+router.delete('/delete', jsonParser, joi.validate(joi.schema.emails.delete), (req, res) => {
+	couchdb.deleteEmails(req.joi.id)
 	.then(() => {
 		return res.sendStatus(200)
 	}).catch(err => {
@@ -139,8 +133,8 @@ router.delete('/delete', jsonParser, (req, res) => {
 })
 
 // TODO: make this work + test it
-router.post('/search', jsonParser, (req, res) => {
-	couchdb.searchEmails(req.body.searchText)
+router.post('/search', jsonParser, joi.validate(joi.schema.emails.search), (req, res) => {
+	couchdb.searchEmails(req.joi.searchText)
 	.then(emails => {
 		return res.send(emails)
 	}).catch(err => {
@@ -149,15 +143,8 @@ router.post('/search', jsonParser, (req, res) => {
 	})
 })
 
-router.post('/copy', jsonParser, (req, res) => {
-	const id = req.body.id
-
-	// guard clause: prevent non-string ID
-	if (!id || typeof id !== 'string') {
-		return res.status(400).json({message: 'Did not pass valid email to duplicate'})
-	}
-
-	couchdb.duplicateEmail(id)
+router.post('/copy', jsonParser, joi.validate(joi.schema.emails.duplicate), (req, res) => {
+	couchdb.duplicateEmail(req.joi.id)
 	.then(ok => {
 		return couchdb.getEmailByID(ok.data.id)
 	}).then((email) => {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -101,25 +101,16 @@ router.get('/:id', joi.validate(joi.schema.emails.getOne), (req, res) => {
 	})
 })
 
-router.put('/:id', jsonParser, (req, res) => {
-	const id = req.params.id
-	let reqDoc = req.body.doc
-	couchdb.putEmail(id, reqDoc)
-		.then((success) => {
-			if(success) {
-				couchdb.getEmailByID(success.data.id)
-				.then(successDoc => {
-					return res.status(200).send(successDoc.data)
-				})
-			}
-		})
-		.catch(err => {
-			console.log(err)
-			res.status(err.response.status).send(err.message)
-			winston.error(err)
-		})
-
-
+router.put('/:id', jsonParser, joi.validate(joi.schema.emails.put), (req, res) => {
+	couchdb.putEmail(req.joi.id, req.joi.doc)
+	.then((success) => {
+		return couchdb.getEmailByID(success.data.id)
+	}).then((doc) => {
+		return res.status(200).send(doc.data)
+	}).catch(err => {
+		winston.error(err)
+		return res.sendStatus(500)
+	})
 })
 
 router.delete('/delete', jsonParser, joi.validate(joi.schema.emails.delete), (req, res) => {


### PR DESCRIPTION
This adds validation middleware for each email route that needs params/body validation.

Params and body get collected into the `req.joi` object, so when accessing this data, notice that the code below now does:

```js
couchdb.createEmail(req.joi.id, req.joi.doc)
```
instead of

```js
couchdb.createEmail(req.params.id, req.body.doc)
```

This helps in a couple ways!

1. Any request that actually makes it through to the final request handler is guaranteed to have valid parameters -- if it didn't, it would have already sent back a 400 Bad Request
2. You don't need to keep track of whether a piece of data was passed in params or in body, you just check the `req.joi` object

The only other change (other than adding tests) is in `mci-couchdb` itself -- I noticed in my previous code, I was added a creation timestamp as well as an update timestamp on every `putEmail` ... you wisely commented that out.

I have now added the creation timestamp to the `createEmail` method. Added some tests and what not.

Let me know if you hit any issues (again) with the package.json or the indenting/tabs. Hopefully that should be cleared up!